### PR TITLE
Check for kfdef on apiextensions/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # odh-operator-test-harness
 Test harness for Open Data Hub operator
+
+### Running Locally
+To run the test locally, you will need to build the image and run the container image with a valid kubeconfig file mounted in the file
+
+```
+$ make
+$ podman build -f Dockerfile -t odh-operator-test-harness:latest .
+$ podman run --rm -v ~/.kube:/.kube:z -it odh-operator-test-harness:latest
+
+  Running Suite: Odh Operator Test Harness
+  ========================================
+  Random Seed: 1635881932
+  Will run 1 of 1 specs
+
+  •
+  JUnit report was created: /test-run-results/junit-odh-operator.xml
+
+  Ran 1 of 1 Specs in 0.119 seconds
+  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
+  PASS
+```

--- a/pkg/tests/odh_operator_tests.go
+++ b/pkg/tests/odh_operator_tests.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("ODH Operator Tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make sure the CRD exists
-		_, err = apiextensions.ApiextensionsV1beta1().CustomResourceDefinitions().Get("kfdefs.kfdef.apps.kubeflow.org", v1.GetOptions{})
+		_, err = apiextensions.ApiextensionsV1().CustomResourceDefinitions().Get("kfdefs.kfdef.apps.kubeflow.org", v1.GetOptions{})
 
 		if err != nil {
 			metadata.Instance.FoundCRD = false


### PR DESCRIPTION
Update the operator test to check for the KfDef CRD on the apiextensions/v1 endpoint

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>